### PR TITLE
[refactor] Ticker 시세 데이터 누적 저장 처리

### DIFF
--- a/src/main/java/com/tickit/batch/domain/Ticker.java
+++ b/src/main/java/com/tickit/batch/domain/Ticker.java
@@ -9,6 +9,8 @@ import com.tickit.batch.adapter.upbit.dto.TickerResponse;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -23,6 +25,9 @@ import lombok.extern.slf4j.Slf4j;
 public class Ticker {
 
 	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
 	@Column(name = "market", nullable = false, length = 20)
 	private String market;
 

--- a/src/main/java/com/tickit/batch/item/writer/TickerWriter.java
+++ b/src/main/java/com/tickit/batch/item/writer/TickerWriter.java
@@ -35,30 +35,21 @@ public class TickerWriter implements ItemWriter<List<Ticker>> {
 		log.info("[Writer] Chunk 수신: {}개 리스트", items.size());
 
 		AtomicInteger totalSaved = new AtomicInteger(0);
-		AtomicInteger totalUpdated = new AtomicInteger(0);
 
 		for(List<Ticker> tickerList : items){
 			log.info("[Writer] 처리할 Ticker 수: {}", tickerList.size());
 
 			for (Ticker ticker : tickerList){
 				try {
-					tickerRepository.findById(ticker.getMarket())
-						.ifPresentOrElse(
-							existing -> {
-								existing.update(ticker);
-								totalUpdated.incrementAndGet();
-							},
-							() -> {
-								tickerRepository.save(ticker);
-								totalSaved.incrementAndGet();							}
-						);
+					tickerRepository.save(ticker);
+					totalSaved.incrementAndGet();
 				} catch (Exception e){
 					log.error("[Writer] Ticker 저장 중 오류 발생: market = {}, error = {}",  ticker.getMarket(), e.getMessage(), e);
 				}
 			}
 		}
 
-		log.info("[Writer] 저장 완료 - 신규 저장: {}개, 기존 업데이트: {}개", totalSaved, totalUpdated);
+		log.info("[Writer] 저장 완료 - 신규 저장: {}개", totalSaved.get());
 
 		MDC.remove("traceId");
 	}

--- a/src/main/java/com/tickit/batch/repository/TickerRepository.java
+++ b/src/main/java/com/tickit/batch/repository/TickerRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 import com.tickit.batch.domain.Ticker;
 
 @Repository
-public interface TickerRepository extends JpaRepository<Ticker, String> {
+public interface TickerRepository extends JpaRepository<Ticker, Long> {
 }


### PR DESCRIPTION
## ⛳️ PR Summary
Ticker 시세 데이터 누적 저장 처리

## 📋 PR 상세 설명
기존 로직은 같은 마켓코드에 대해 기존 데이터가 존재하면 `update`, 없으면 `insert` 방식으로 동작하여 시계열 데이터 누적이 불가능했다. 이를 모든 시세 데이터를 그대로 저장하여 시계열 데이터로 누적할 수 있도록 변경하였다.

**주요 변경 사항** 
- **`Ticker`**: `ID` 필드를 `Long` 타입으로 추가하고 `@GeneratedValue(strategy = GenerationType.IDENTITY)` 설정
- **`TickerRepository`**: `JpaRepository`의 `ID` 타입을 `String`에서 `Long`으로 변경
- **`TickerWriter`**: `findById` 및 `update` 로직 제거, 모든 Ticker 객체에 대해 `save()`만 호출하도록 변경

---
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는 경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## ✅ Check List

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.